### PR TITLE
Fix | don't chose info field when searching for format field in sample | BLVR-1185

### DIFF
--- a/src/vcfio/variant/variant.py
+++ b/src/vcfio/variant/variant.py
@@ -29,12 +29,9 @@ class Variant(VariantProperties):
 
     def get_value(self, key: AnyStr, sample_name: AnyStr, empty_value='.', default='.', infer_type=False):
         """
-        Try to find the key in the sample
-            If not found try to find it in self.info
-                If not found return default
+        Try to find the key in the sample, If not found return default
         """
-        return self.samples[sample_name].get(key, empty_value=empty_value, infer_type=infer_type) or \
-               self.info.get(key, empty_value=empty_value, default=default, infer_type=infer_type)
+        return self.samples[sample_name].get(key, empty_value=empty_value, default=default, infer_type=infer_type)
 
     def stringify_info(self):
         fields = []

--- a/tests/test_variant.py
+++ b/tests/test_variant.py
@@ -21,6 +21,7 @@ class TestVariant:
         ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420', ['proband'], 'DP', 200),
         ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420', ['proband'], 'AF', [0.8, 0.15]),
         ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420', ['proband'], 'XX', '.'),
+        ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00;XY=20	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420', ['proband'], 'XY', '.'),
     ])
     def test_get_value(self, line, sample_names, key, expected_output):
         variant = Variant.from_variant_line(line, sample_names=sample_names)


### PR DESCRIPTION

Fixes issue [BLVR-1185](https://jira.illumina.com/browse/BLVR-1185)

when getting a value for a specific sample current behavior is to search in format field, and if not found search in info field. this is wrong usage of the file (the field in the info is not applicable automatically to all samples)
