### PR TITLE
Fix | Use string split instead of regex | MNDL-916

### DIFF
--- a/src/vcfio/variant/variant.py
+++ b/src/vcfio/variant/variant.py
@@ -1,9 +1,6 @@
-import hashlib
-import re
 from cmath import nan
 from typing import AnyStr
 from typing import Iterable
-from typing import TextIO
 
 from vcfio.utils.consts import VALID_CHROMOSOMES
 from vcfio.utils.enums import Zygosity
@@ -72,7 +69,7 @@ class Variant(VariantProperties):
         return self.chromosome in VALID_CHROMOSOMES
 
     @classmethod
-    def from_variant_line(cls, variant_line: TextIO, sample_names: Iterable[AnyStr] = (),
+    def from_variant_line(cls, variant_line: str, sample_names: Iterable[AnyStr] = (),
                           default_sample_format: Iterable[AnyStr] = ()) -> 'Variant':
         """
         Create a Variant instance from a raw line
@@ -80,7 +77,7 @@ class Variant(VariantProperties):
             Input - "chr3    2956    .       G       GACACACAC       100     .       AC=1;AN=2;DP4=1,0,6,0;DP=7;IDV=6;IMF=0.857143;INDEL;MQ0F=0;MQ=51;SGB=-0.616816;VDB=0.041536;multiallele.gid=1   GT:PL:AD        0/1:111,0,113:0,4"
             Output - Variant(chromosome=chr3,position=2956,ref=G,alt=['GACACACAC'])
         """
-        variant_line_values = re.split('\t| +', variant_line.strip('\n'))
+        variant_line_values = variant_line.strip('\n').split('\t')
 
         if len(variant_line_values) < 8:
             raise InvalidVariantLine(variant_line)

--- a/tests/test_variant.py
+++ b/tests/test_variant.py
@@ -27,7 +27,7 @@ class TestVariant:
 
     @pytest.mark.parametrize("line, sample_names, expected_output", [
         ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420', ['proband'], ['0/1:10,160,30:0.8,0.15:200:420']),
-        ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420  0/1:10,160,30:0.8,0.15:200:420', ['proband', 'father'], ['0/1:10,160,30:0.8,0.15:200:420', '0/1:10,160,30:0.8,0.15:200:420']),
+        ('chr1	726	.	G	C,T	500	.	DP=200;MQ=250.00	GT:AD:AF:DP:GQ	0/1:10,160,30:0.8,0.15:200:420	0/1:10,160,30:0.8,0.15:200:420', ['proband', 'father'], ['0/1:10,160,30:0.8,0.15:200:420', '0/1:10,160,30:0.8,0.15:200:420']),
     ])
     def test_stringify_samples(self, line, sample_names, expected_output):
         variant = Variant.from_variant_line(line, sample_names=sample_names)


### PR DESCRIPTION
### WHY are these changes introduced?

I ran a profiler on vcfio's performance when just reading a file, no parsing at all.
I discovered the `re.split()` takes up 87% of the time !! 

![image](https://github.com/emedgene/vcfio/assets/25158615/9c2e2855-2b8c-4e5d-8d6b-affef4d698fb)

I suggest using python's `str.split()` which is much faster. see profiling after the change:

![image](https://github.com/emedgene/vcfio/assets/25158615/d7e25522-9526-40c8-8897-ac049211c5d7)

It does come with a caveat: we will no longer allow columns separated by whitespaces or more than one tab.
However, according to the vcf specs, tab is the only valid separator.

### WHAT is this pull request doing?

a simple one line change: replace `re.split` with `str.split`
